### PR TITLE
Display assignee on questions index

### DIFF
--- a/backend/app/controllers/api/v1/questions_controller.rb
+++ b/backend/app/controllers/api/v1/questions_controller.rb
@@ -3,7 +3,7 @@ module API::V1
     before_action :ensure_valid_api_key!, only: [:create, :update]
 
     def index
-      @questions = Question.includes(:user, :answers).order(created_at: :desc)
+      @questions = Question.includes(:user, :answers, :assignee).order(created_at: :desc)
       @questions = @questions.open if params[:status] == "open"
       @questions = @questions.page(params[:page])
 

--- a/frontend/app/templates/questions/index.hbs
+++ b/frontend/app/templates/questions/index.hbs
@@ -18,6 +18,7 @@
       <th>User</th>
       <th>Title</th>
       <th>Status</th>
+      <th>Assignee</th>
     </tr>
   </thead>
   <tbody>
@@ -30,6 +31,7 @@
             {{question.status}}
           </span>
         </td>
+        <td>{{user-avatar user=question.assignee}}</td>
       </tr>
     {{/each}}
   </tbody>


### PR DESCRIPTION
There is an issue with the API response not including the assignees.
I’m not sure how to get AMS to include those. I'm going to wait until we get things going to start worrying too much about those type of performance issues.
